### PR TITLE
Rename the package from wp to wp-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WordPress toolkit
 
-[![Packagist Version](https://img.shields.io/github/v/release/studiometa/wp?include_prereleases&label=packagist&style=flat-square)](https://packagist.org/packages/studiometa/wp)
-[![License MIT](https://img.shields.io/packagist/l/studiometa/wp?style=flat-square)](https://packagist.org/packages/studiometa/wp)
+[![Packagist Version](https://img.shields.io/github/v/release/studiometa/wp-toolkit?include_prereleases&label=packagist&style=flat-square)](https://packagist.org/packages/studiometa/wp)
+[![License MIT](https://img.shields.io/packagist/l/studiometa/wp-toolkit?style=flat-square)](https://packagist.org/packages/studiometa/wp)
 
 > A PHP toolkit to boost your WordPress development! 🚀
 
@@ -10,15 +10,15 @@
 Install the package via Composer: 
 
 ```bash
-composer require studiometa/wp
+composer require studiometa/wp-toolkit
 ```
 
 ## Usage
 
 ```php
-use Studiometa\WP\Assets;
-use Studiometa\WP\Cleanup;
-use Studiometa\WP\Builders\PostTypeBuilder;
+use Studiometa\WPToolkit\Assets;
+use Studiometa\WPToolkit\Cleanup;
+use Studiometa\WPToolkit\Builders\PostTypeBuilder;
 
 // Load assets from `assets.yaml` configuration
 new Assets( get_template_directory() );

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "studiometa/wp",
+  "name": "studiometa/wp-toolkit",
   "version": "1.0.0-alpha2",
   "description": "WordPress utilities for Studio Meta.",
   "license": "MIT",
@@ -20,7 +20,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Studiometa\\WP\\": "src/"
+      "Studiometa\\WPToolkit\\": "src/"
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "studiometa/wp-toolkit",
-  "version": "1.0.0-alpha2",
+  "version": "1.0.0-alpha3",
   "description": "WordPress utilities for Studio Meta.",
   "license": "MIT",
   "type": "library",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="studiometa-wp-assets">
+<ruleset name="studiometa-wp-toolkit">
   <!-- Define file and folders to lint -->
   <file>./src/</file>
   <file>./tests/</file>

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -2,7 +2,7 @@
 /**
  * Manage your WordPress assets with a simple YAML configuration file.
  *
- * @package    studiometa/wp
+ * @package    studiometa/wp-toolkit
  * @author     Titouan Mathis <titouan@studiometa.fr>
  * @copyright  2020 Studio Meta
  * @license    https://opensource.org/licenses/MIT

--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -2,7 +2,7 @@
 /**
  * Utilities to configure custom post types.
  *
- * @package    studiometa/wp
+ * @package    studiometa/wp-toolkit
  * @author     Lucas Simeon <lucas.s@studiometa.fr>
  * @copyright  2020 Studio Meta
  * @license    https://opensource.org/licenses/MIT
@@ -10,7 +10,7 @@
  * @version    1.0.0
  */
 
-namespace Studiometa\WP\Builders;
+namespace Studiometa\WPToolkit\Builders;
 
 /**
  * Cleanup a WordPress project for security and performance.

--- a/src/Builders/PostTypeBuilder.php
+++ b/src/Builders/PostTypeBuilder.php
@@ -2,7 +2,7 @@
 /**
  * Utilities to configure custom post types.
  *
- * @package    studiometa/wp
+ * @package    studiometa/wp-toolkit
  * @author     Lucas Simeon <lucas.s@studiometa.fr>
  * @copyright  2020 Studio Meta
  * @license    https://opensource.org/licenses/MIT
@@ -10,7 +10,7 @@
  * @version    1.0.0
  */
 
-namespace Studiometa\WP\Builders;
+namespace Studiometa\WPToolkit\Builders;
 
 /**
  * Build a custom post type.

--- a/src/Builders/TaxonomyBuilder.php
+++ b/src/Builders/TaxonomyBuilder.php
@@ -2,7 +2,7 @@
 /**
  * Utilities to configure custom post types.
  *
- * @package    studiometa/wp
+ * @package    studiometa/wp-toolkit
  * @author     Lucas Simeon <lucas.s@studiometa.fr>
  * @copyright  2020 Studio Meta
  * @license    https://opensource.org/licenses/MIT
@@ -10,7 +10,7 @@
  * @version    1.0.0
  */
 
-namespace Studiometa\WP\Builders;
+namespace Studiometa\WPToolkit\Builders;
 
 /**
  * Build a custom post type.

--- a/src/Cleanup.php
+++ b/src/Cleanup.php
@@ -2,7 +2,7 @@
 /**
  * Utilities to clean up a WordPress project.
  *
- * @package    studiometa/wp
+ * @package    studiometa/wp-toolkit
  * @author     Titouan Mathis <titouan@studiometa.fr>
  * @copyright  2020 Studio Meta
  * @license    https://opensource.org/licenses/MIT

--- a/tests/Builder/PostTypeBuilderTest.php
+++ b/tests/Builder/PostTypeBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Studiometa\WP\Builders\PostTypeBuilder;
+use Studiometa\WPToolkit\Builders\PostTypeBuilder;
 
 it(
 	'should register a custom post type',

--- a/tests/Builder/TaxonomyBuilderTest.php
+++ b/tests/Builder/TaxonomyBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Studiometa\WP\Builders\TaxonomyBuilder;
+use Studiometa\WPToolkit\Builders\TaxonomyBuilder;
 
 it(
 	'should register a custom taxonomy',


### PR DESCRIPTION
To follow our existing convention: scss-toolkit, js-toolkit, twig-toolkit, etc.