### PR TITLE
Add a transient cleaner tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,49 @@ $tax->set_post_types( 'product' )
   ->set_labels( 'Product Category', 'Product Categories' )
   ->register();
 ```
+
+## Transient Cleaner
+### Usage
+> **Important** Transients keys must be prefixed with transient cleaner prefix (`TransientCleaner::PREFIX`) to be tracked.
+
+```php
+use Studiometa\WPToolkit\TransientCleaner;
+
+// 1. Set a transient with transient cleaner prefix.
+if ( $my_condition ) {
+  set_transient(
+    TransientCleaner::PREFIX . 'transient_key',
+    'example'
+  );
+}
+
+// 2. Initialize transient cleaner.
+$transient_cleaner = TransientCleaner::get_instance(
+  array(
+    'post'   => array(
+      'all'           => array(
+        TransientCleaner::PREFIX . 'transient_key',
+      ),
+      'post_type_key' => array(
+        TransientCleaner::PREFIX . 'transient_key',
+        TransientCleaner::PREFIX . 'transient_key_1',
+      )
+    ),
+    'term'   => array(
+      'all'                    => array(),
+      'your_taxonomy_type_key' => array(),
+      'category'               => array(),
+    ),
+    'option' => array(
+      'all'             => array(),
+      'option_key'      => array(),
+      'blogdescription' => array(),
+    ),
+  )
+);
+
+// Update config if needed.
+$transient_cleaner->set_config(array());
+
+// 3. Insert/Update post/term/option to see your transients deleted based on your config.
+``` 

--- a/src/TransientCleaner.php
+++ b/src/TransientCleaner.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * Delete WordPress transients on content save, based on user-input configuration.
+ *
+ * @package    studiometa/wp-toolkit
+ * @author     Studio Meta <agence@studiometa.fr>
+ * @copyright  2020 Studio Meta
+ * @license    https://opensource.org/licenses/MIT
+ * @since      1.0.0
+ * @version    1.0.0
+ */
+
+namespace Studiometa\WPToolkit;
+
+/**
+ * TransientCleaner class.
+ */
+class TransientCleaner {
+	const PREFIX                   = 'wp_transient_cleaner_';
+	const OPTION_STORED_TRANSIENTS = self::PREFIX . 'stored_transients';
+
+	/**
+	 * Class instance
+	 *
+	 * @var object|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Transients configuration.
+	 *
+	 * @var array
+	 */
+	private $config = array();
+
+	/**
+	 * Stored transients.
+	 *
+	 * @var array|bool
+	 */
+	private $stored_transients;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $config Configuration.
+	 */
+	public function __construct( $config = array() ) {
+		$this->set_stored_transients( get_option( self::OPTION_STORED_TRANSIENTS ) );
+		$this->set_config( $config );
+		$this->define_public_hooks();
+	}
+
+	/**
+	 * Get class instance.
+	 *
+	 * @param array $config Configuration.
+	 *
+	 * @return object Class instance
+	 */
+	public static function get_instance( $config = array() ) {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new TransientCleaner( $config );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function define_public_hooks() {
+		add_action( 'save_post', array( $this, 'post_transient_cleaner' ), 10, 2 );
+		add_action( 'edit_term', array( $this, 'term_transient_cleaner' ), 10, 3 );
+		add_action( 'updated_option', array( $this, 'option_transient_cleaner' ), 10, 2 );
+		add_action( 'setted_transient', array( $this, 'store_transient_key' ) );
+		add_filter( 'pre_update_option_' . self::OPTION_STORED_TRANSIENTS, array( $this, 'merge_stored_transients_option_values' ), 10, 3 );
+		add_filter( 'update_option_' . self::OPTION_STORED_TRANSIENTS, array( $this, 'set_stored_transients' ), 20, 1 );
+	}
+
+	/**
+	 * Get config.
+	 *
+	 * @return array
+	 */
+	public function get_config() {
+		return $this->config;
+	}
+
+	/**
+	 * Set config.
+	 *
+	 * @param array $config Configuration.
+	 *
+	 * @return object
+	 */
+	public function set_config( array $config ) {
+		$this->config = $config;
+
+		return $this;
+	}
+
+	/**
+	 * Get stored_transients.
+	 *
+	 * @return array|bool
+	 */
+	public function get_stored_transients() {
+		return $this->stored_transients;
+	}
+
+	/**
+	 * Set stored_transients.
+	 *
+	 * @param array|bool $value New value.
+	 *
+	 * @return object
+	 */
+	public function set_stored_transients( $value ) {
+		$this->stored_transients = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Merge new stored transient key with others if exists.
+	 *
+	 * @param array|bool $value     New value.
+	 * @param array|bool $old_value Old value.
+	 * @param string     $option    Option.
+	 *
+	 * @return array|bool           New value
+	 */
+	public function merge_stored_transients_option_values( $value, $old_value, $option = null ) {
+		// Return `$value` if no previous value.
+		if ( false === $old_value ) {
+			return $value;
+		}
+
+		// Do nothing if transient key already exists in stored transients.
+		if ( is_array( $value ) && is_array( $old_value ) ) {
+			if ( isset( $value[0] ) && true === in_array( $value[0], $old_value, true ) ) {
+				return $old_value;
+			}
+
+			// Merge old and new values.
+			return array_merge( $old_value, $value );
+		}
+
+		return $old_value;
+	}
+
+	/**
+	 * Store transient key in option on save.
+	 *
+	 * @param string $transient_key Transient key.
+	 *
+	 * @see self::merge_stored_transients_option_values
+	 *
+	 * @return bool
+	 */
+	public function store_transient_key( string $transient_key ) {
+		if (
+			false === strpos( $transient_key, self::PREFIX )
+			|| false !== strpos( $transient_key, '_lock' )
+		) {
+			return false;
+		}
+
+		return update_option(
+			self::OPTION_STORED_TRANSIENTS,
+			array( $transient_key )
+		);
+	}
+
+	/**
+	 * Clear transient on post save.
+	 *
+	 * @param mixed $post_id post id.
+	 * @param mixed $post post.
+	 *
+	 * @return bool
+	 */
+	public function post_transient_cleaner( $post_id, $post ) {
+		if ( ! is_array( $this->stored_transients ) || empty( $this->config['post'] ) ) {
+			return false;
+		}
+
+		/*
+			Delete transient based on current post_type and transient key.
+		 */
+		foreach ( $this->config['post'] as $post_type_key => $transient_keys ) {
+			if ( 'all' !== $post_type_key && $post_type_key !== $post->post_type ) {
+				continue;
+			}
+
+			foreach ( $transient_keys as $transient_key ) {
+				foreach ( $this->stored_transients as $stored_transient ) {
+					if ( false === strpos( $stored_transient, $transient_key ) ) {
+						continue;
+					}
+
+					delete_transient( $stored_transient );
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Clear transient on term save.
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param int    $tt_id    Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy.
+	 *
+	 * @return bool
+	 */
+	public function term_transient_cleaner( int $term_id, int $tt_id, string $taxonomy ) {
+		if ( ! is_array( $this->stored_transients ) || empty( $this->config['term'] ) ) {
+			return false;
+		}
+
+		/*
+			Delete transient based on taxonomy and transient key.
+		 */
+		foreach ( $this->config['term'] as $taxonomy_key => $transient_keys ) {
+			if ( 'all' !== $taxonomy_key && $taxonomy_key !== $taxonomy ) {
+				continue;
+			}
+
+			foreach ( $transient_keys as $transient_key ) {
+				foreach ( $this->stored_transients as $stored_transient ) {
+					if ( false === strpos( $stored_transient, $transient_key ) ) {
+						continue;
+					}
+
+					delete_transient( $stored_transient );
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Clear transient on option save.
+	 *
+	 * @param string $option Option key.
+	 *
+	 * @return bool
+	 */
+	public function option_transient_cleaner( string $option ) {
+		if ( ! is_array( $this->stored_transients ) || empty( $this->config['option'] ) ) {
+			return false;
+		}
+
+		/*
+			Delete transient based on post name and transient key.
+		 */
+		foreach ( $this->config['option'] as $option_key => $transient_keys ) {
+			if ( 'all' !== $option_key && false === strpos( $option, $option_key ) ) {
+				continue;
+			}
+
+			foreach ( $transient_keys as $transient_key ) {
+				foreach ( $this->stored_transients as $stored_transient ) {
+					if ( false === strpos( $stored_transient, $transient_key ) ) {
+						continue;
+					}
+
+					delete_transient( $stored_transient );
+				}
+			}
+		}
+
+		return true;
+	}
+}

--- a/src/TransientCleaner.php
+++ b/src/TransientCleaner.php
@@ -16,13 +16,13 @@ namespace Studiometa\WPToolkit;
  * TransientCleaner class.
  */
 class TransientCleaner {
-	const PREFIX                   = 'wp_transient_cleaner_';
+	const PREFIX                   = 'wp_toolkit_transient_cleaner_';
 	const OPTION_STORED_TRANSIENTS = self::PREFIX . 'stored_transients';
 
 	/**
 	 * Class instance
 	 *
-	 * @var object|null
+	 * @var TransientCleaner|null
 	 */
 	private static $instance = null;
 
@@ -45,7 +45,7 @@ class TransientCleaner {
 	 *
 	 * @param array $config Configuration.
 	 */
-	public function __construct( $config = array() ) {
+	public function __construct( array $config = array() ) {
 		$this->set_stored_transients( get_option( self::OPTION_STORED_TRANSIENTS ) );
 		$this->set_config( $config );
 		$this->define_public_hooks();
@@ -54,11 +54,38 @@ class TransientCleaner {
 	/**
 	 * Get class instance.
 	 *
+	 * {@example}
+	 * ```php
+	 * TransientCleaner::get_instance(
+	 *   array(
+	 *     'post' => array(
+	 *       'all' => array(
+	 *         TransientCleaner::PREFIX . 'transient_key',
+	 *       ),
+	 *       'post_type_key' => array(
+	 *         TransientCleaner::PREFIX . 'transient_key',
+	 *         TransientCleaner::PREFIX . 'transient_key_1',
+	 *       )
+	 *     ),
+	 *     'term' => array(
+	 *       'all'                    => array(),
+	 *       'your_taxonomy_type_key' => array(),
+	 *       'category'               => array(),
+	 *     ),
+	 *     'option' => array(
+	 *       'all'             => array(),
+	 *       'option_key'      => array(),
+	 *       'blogdescription' => array(),
+	 *     ),
+	 *   )
+	 * );
+	 * ```
+	 *
 	 * @param array $config Configuration.
 	 *
-	 * @return object Class instance
+	 * @return TransientCleaner Class instance
 	 */
-	public static function get_instance( $config = array() ) {
+	public static function get_instance( array $config = array() ) : TransientCleaner {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new TransientCleaner( $config );
 		}
@@ -85,18 +112,46 @@ class TransientCleaner {
 	 *
 	 * @return array
 	 */
-	public function get_config() {
+	public function get_config() : array {
 		return $this->config;
 	}
 
 	/**
 	 * Set config.
 	 *
+	 * {@example}
+	 * ```php
+	 * TransientCleaner::get_instance()
+	 *   ->set_config(
+	 *     array(
+	 *       'post' => array(
+	 *         'all' => array(
+	 *           TransientCleaner::PREFIX . 'transient_key',
+	 *         ),
+	 *         'post_type_key' => array(
+	 *           TransientCleaner::PREFIX . 'transient_key',
+	 *           TransientCleaner::PREFIX . 'transient_key_1',
+	 *         )
+	 *       ),
+	 *       'term' => array(
+	 *         'all'                    => array(),
+	 *         'your_taxonomy_type_key' => array(),
+	 *         'category'               => array(),
+	 *       ),
+	 *       'option' => array(
+	 *         'all'             => array(),
+	 *         'option_key'      => array(),
+	 *         'blogdescription' => array(),
+	 *       ),
+	 *     )
+	 *   );
+	 * ```
+	 *
 	 * @param array $config Configuration.
 	 *
-	 * @return object
+	 * @return TransientCleaner
 	 */
-	public function set_config( array $config ) {
+	public function set_config( array $config ) : TransientCleaner {
 		$this->config = $config;
 
 		return $this;
@@ -116,9 +171,9 @@ class TransientCleaner {
 	 *
 	 * @param array|bool $value New value.
 	 *
-	 * @return object
+	 * @return TransientCleaner
 	 */
-	public function set_stored_transients( $value ) {
+	public function set_stored_transients( $value ) : TransientCleaner {
 		$this->stored_transients = $value;
 
 		return $this;
@@ -129,11 +184,10 @@ class TransientCleaner {
 	 *
 	 * @param array|bool $value     New value.
 	 * @param array|bool $old_value Old value.
-	 * @param string     $option    Option.
 	 *
 	 * @return array|bool           New value
 	 */
-	public function merge_stored_transients_option_values( $value, $old_value, $option = null ) {
+	public function merge_stored_transients_option_values( $value, $old_value ) {
 		// Return `$value` if no previous value.
 		if ( false === $old_value ) {
 			return $value;
@@ -161,7 +215,7 @@ class TransientCleaner {
 	 *
 	 * @return bool
 	 */
-	public function store_transient_key( string $transient_key ) {
+	public function store_transient_key( string $transient_key ) : bool {
 		if (
 			false === strpos( $transient_key, self::PREFIX )
 			|| false !== strpos( $transient_key, '_lock' )
@@ -183,7 +237,7 @@ class TransientCleaner {
 	 *
 	 * @return bool
 	 */
-	protected function object_transient_cleaner( string $type, callable $validator ) {
+	protected function object_transient_cleaner( string $type, callable $validator ) : bool {
 		if ( ! is_array( $this->stored_transients ) || empty( $this->config[ $type ] ) ) {
 			return false;
 		}
@@ -210,12 +264,12 @@ class TransientCleaner {
 	/**
 	 * Clear transient on post save.
 	 *
-	 * @param mixed $post_id post id.
-	 * @param mixed $post post.
+	 * @param mixed    $post_id post id.
+	 * @param \WP_Post $post post.
 	 *
 	 * @return bool
 	 */
-	public function post_transient_cleaner( $post_id, $post ) {
+	public function post_transient_cleaner( $post_id, \WP_Post $post ) : bool {
 		return $this->object_transient_cleaner(
 			'post',
 			function( $key ) use ( $post ) {
@@ -233,7 +287,7 @@ class TransientCleaner {
 	 *
 	 * @return bool
 	 */
-	public function term_transient_cleaner( int $term_id, int $tt_id, string $taxonomy ) {
+	public function term_transient_cleaner( int $term_id, int $tt_id, string $taxonomy ) : bool {
 		return $this->object_transient_cleaner(
 			'term',
 			function( $key ) use ( $taxonomy ) {
@@ -249,7 +303,7 @@ class TransientCleaner {
 	 *
 	 * @return bool
 	 */
-	public function option_transient_cleaner( string $option ) {
+	public function option_transient_cleaner( string $option ) : bool {
 		return $this->object_transient_cleaner(
 			'option',
 			function( $key ) use ( $option ) {

--- a/src/TransientCleaner.php
+++ b/src/TransientCleaner.php
@@ -213,7 +213,7 @@ class TransientCleaner {
 	 * @param mixed $post_id post id.
 	 * @param mixed $post post.
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public function post_transient_cleaner( $post_id, $post ) {
 		return $this->object_transient_cleaner(
@@ -231,7 +231,7 @@ class TransientCleaner {
 	 * @param int    $tt_id    Term taxonomy ID.
 	 * @param string $taxonomy Taxonomy.
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public function term_transient_cleaner( int $term_id, int $tt_id, string $taxonomy ) {
 		return $this->object_transient_cleaner(
@@ -247,7 +247,7 @@ class TransientCleaner {
 	 *
 	 * @param string $option Option key.
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public function option_transient_cleaner( string $option ) {
 		return $this->object_transient_cleaner(

--- a/tests/TransientCleanerTest.php
+++ b/tests/TransientCleanerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Studiometa\WPToolkit\TransientCleaner;
+
+/**
+ * PostTypeBuilder test case.
+ */
+class TransientCleanerTest extends WP_UnitTestCase {
+	const POST_TRANSIENT_KEY   = TransientCleaner::PREFIX . 'transient_cleaner_post';
+	const TERM_TRANSIENT_KEY   = TransientCleaner::PREFIX . 'transient_cleaner_term';
+	const OPTION_TRANSIENT_KEY = TransientCleaner::PREFIX . 'transient_cleaner_option';
+
+	/**
+	 * Initialize transient cleaner based on config.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->config = array(
+			'post'   => array(
+				'post' => array(
+					self::POST_TRANSIENT_KEY,
+				),
+			),
+			'term'   => array(
+				'post_tag' => array(
+					self::TERM_TRANSIENT_KEY,
+				),
+			),
+			'option' => array(
+				'baz_option' => array(
+					self::OPTION_TRANSIENT_KEY,
+				),
+			),
+		);
+
+		$this->transient_cleaner = TransientCleaner::get_instance( $this->config );
+	}
+
+	/**
+	 * Test set/get config.
+	 *
+	 * @return void
+	 */
+	public function test_set_get_config() {
+		$config_1 = $this->transient_cleaner->get_config();
+		$this->transient_cleaner->set_config(
+			array_merge(
+				$config_1,
+				array( 'foo' => array() )
+			)
+		);
+		$config_2 = $this->transient_cleaner->get_config();
+
+		$this->assertIsArray( $config_2 );
+		$this->assertNotEmpty( $config_2 );
+		$this->assertEquals( count( $config_1 ), count( $config_2 ) - 1 );
+	}
+
+	/**
+	 * Test set/get stored_transients.
+	 *
+	 * @return void
+	 */
+	public function test_set_get_stored_transients() {
+		$stored_transients_1 = $this->transient_cleaner->get_stored_transients();
+		$this->transient_cleaner->set_stored_transients(
+			array( 'foo' )
+		);
+		$stored_transients_2 = $this->transient_cleaner->get_stored_transients();
+
+		$this->assertEquals( array( 'foo' ), $stored_transients_2 );
+	}
+
+	/**
+	 * Test merge_stored_transients_option_values.
+	 *
+	 * @return void
+	 */
+	public function test_merge_stored_transients_option_values() {
+		$test_no_old_value = $this->transient_cleaner->merge_stored_transients_option_values( 'foo', false );
+		$test_old_value    = $this->transient_cleaner->merge_stored_transients_option_values( 'foo', 'foo_old' );
+		$test_merge_values = $this->transient_cleaner->merge_stored_transients_option_values( array( 'foo' ), array( 'foo_old' ) );
+
+		$this->assertEquals( 'foo', $test_no_old_value );
+		$this->assertEquals( 'foo_old', $test_old_value );
+		$this->assertEquals( array( 'foo_old', 'foo' ), $test_merge_values );
+	}
+
+	/**
+	 * Test store transient.
+	 *
+	 * @return void
+	 */
+	public function test_store_transient_key() {
+		$test_fail    = $this->transient_cleaner->store_transient_key( 'foo' );
+		$test_success = $this->transient_cleaner->store_transient_key( TransientCleaner::PREFIX . 'foo' );
+
+		$this->assertFalse( $test_fail );
+		$this->assertTrue( $test_success );
+	}
+}

--- a/tests/TransientCleanerTest.php
+++ b/tests/TransientCleanerTest.php
@@ -91,9 +91,9 @@ class TransientCleanerTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_merge_stored_transients_option_values() {
-		$test_no_old_value = $this->transient_cleaner->merge_stored_transients_option_values( 'foo', false );
-		$test_old_value    = $this->transient_cleaner->merge_stored_transients_option_values( 'foo', 'foo_old' );
-		$test_merge_values = $this->transient_cleaner->merge_stored_transients_option_values( array( 'foo' ), array( 'foo_old' ) );
+		$test_no_old_value                = $this->transient_cleaner->merge_stored_transients_option_values( 'foo', false );
+		$test_old_value                   = $this->transient_cleaner->merge_stored_transients_option_values( 'foo', 'foo_old' );
+		$test_merge_values                = $this->transient_cleaner->merge_stored_transients_option_values( array( 'foo' ), array( 'foo_old' ) );
 		$test_merge_values_already_exists = $this->transient_cleaner->merge_stored_transients_option_values( array( 'foo' ), array( 'foo_old', 'foo' ) );
 
 		$this->assertEquals( 'foo', $test_no_old_value );
@@ -121,9 +121,7 @@ class TransientCleanerTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_post_transient_cleaner() {
-		$post            = new \stdClass();
-		$post->post_type = 'post';
-
+		$post         = $this->factory->post->create_and_get();
 		$test_success = $this->transient_cleaner->post_transient_cleaner( 1, $post );
 
 		$config_1 = $this->transient_cleaner->get_config();


### PR DESCRIPTION
## Motivation
Rather than (or in addition to) set a lifetime to a transient, we often need to clean a transient when a post is saved to update the front-office. So this PR introduce a way to clean transients based on a user-input configuration like the one below.
```php
[
  # Transient to clean on post update.
  'post' => [
    'all' => [
      'transient_key',
    ]
    'post_type_key' => [
      'transient_key',
      'transient_key_1',
    ]
  ],
  # Transient to clean on term update.
  'term' => [
    'all' => []
    'your_taxonomy_type_key' => []
  ],
  # Transient to clean on option update.
  'option' => [
    'all' => []
    'option_key' => []
  ],
]
```

## Todo
- [x] Add unit and functionnal test.