### PR TITLE
Keep theme assets version

### DIFF
--- a/src/Cleanup.php
+++ b/src/Cleanup.php
@@ -84,15 +84,19 @@ class Cleanup {
 	}
 
 	/**
-	 * Suppress version number in enqued css & js files
+	 * Suppress version number in enqued css & js files.
+	 * Except for themes assets where version isn't a security breach.
+	 *
+	 * @see Studiometa\WP\Assets::register()
 	 *
 	 * @param  string $src The source path of the asset.
 	 * @return string
 	 */
 	public function remove_version_css_js( string $src ):string {
-		if ( strpos( $src, 'ver=' ) ) {
+		if ( strpos( $src, 'ver=' ) && false === strpos( $src, content_url( 'themes' ) ) ) {
 			$src = remove_query_arg( 'ver', $src );
 		}
+
 		return $src;
 	}
 

--- a/tests/CleanupTest.php
+++ b/tests/CleanupTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Studiometa\WPToolkit\Cleanup;
+
+/**
+ * CleanupTest test case.
+ */
+class CleanupTest extends WP_UnitTestCase {
+	public function setUp() {
+		parent::setUp();
+
+		$this->cleanup = new Cleanup();
+	}
+
+	/**
+	 * Test remove css and js version.
+	 *
+	 * @return void
+	 */
+	public function test_remove_version_css_js() {
+		$themes_uri = content_url( 'themes' );
+		$theme_src  = $themes_uri . '/example/example.js?ver=2.0.0';
+		$other_src  = 'https://example.org/example.js?ver=2.0.0';
+
+		$updated_theme_src = $this->cleanup->remove_version_css_js( $theme_src );
+		$updated_other_src = $this->cleanup->remove_version_css_js( $other_src );
+
+		$this->assertFalse( strpos( $updated_other_src, 'ver=' ) );
+		$this->assertNotFalse( strpos( $updated_theme_src, 'ver=' ) );
+	}
+}


### PR DESCRIPTION
Hi @studiometa/wordpress 

Presently, all assets version are removed on load (to prevent plugin version to be public) so we lost the pros of browser cache invalidation.

Theme assets versions are tracked depends on [file content hash](https://github.com/studiometa/wp-toolkit/blob/master/src/Assets.php#L178), so it is not a security breach to keep theirs versions public.

This PR, check if asset is loaded from theme and keep version instead of removing it.