### PR TITLE
Feature/update namespace

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -13,7 +13,6 @@
 namespace Studiometa\WPToolkit;
 
 use Symfony\Component\Yaml\Yaml;
-use Symfony\Component\Yaml\Exception\ParseException;
 
 /**
  * Helper class to manage a theme's assets.

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -10,7 +10,7 @@
  * @version    1.0.0
  */
 
-namespace Studiometa\WP;
+namespace Studiometa\WPToolkit;
 
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;

--- a/src/Cleanup.php
+++ b/src/Cleanup.php
@@ -10,7 +10,7 @@
  * @version    1.0.0
  */
 
-namespace Studiometa\WP;
+namespace Studiometa\WPToolkit;
 
 /**
  * Cleanup a WordPress project for security and performance.


### PR DESCRIPTION
Hello ! 

Two small fixes in this PR : 

- Correct the namespace of `Assets` and `Cleanup` class, to be compliant with PSR4. 
Im working on adding this repo as a dependencie into [create-wordpress-project](https://github.com/studiometa/create-wordpress-project). Those two classes are currently not autoloaded since the namespace does not follow the folder structure. 

- Remove a declared but unused symbol in `Assets` class