### PR TITLE
Plugin helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Functions to interact with WordPress behaviour.
 ```php
 use Studiometa\WPToolkit\Helpers\PluginHelper;
 // Check if a specified plugin is enable.
+use Studiometa\WPToolkit\Helpers\PluginHelper;
 PluginHelper::is_plugin_enabled( 'my-plugin/my-plugin.php' );
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Installation
 
-Install the package via Composer: 
+Install the package via Composer:
 
 ```bash
 composer require studiometa/wp-toolkit
@@ -76,7 +76,7 @@ The `AssetsManager` manager does the heavy lifting of registering and enqueuing 
     <asset-id>: <asset-path-in-theme>
 ```
 
-If used with our [Webpack configuration package](https://github.com/studiometa/webpack-config), you can also specify entrypoints and all their dependencies to be registered and enqueued. 
+If used with our [Webpack configuration package](https://github.com/studiometa/webpack-config), you can also specify entrypoints and all their dependencies to be registered and enqueued.
 
 ```yaml
 all:
@@ -97,8 +97,22 @@ new AssetsManager(
 - `$configuration_filepath` (`string`): path to the `config.yml` file, defaults to `config/assets.yml` in your theme.
 - `$webpack_manifest_filepath` (`string`), path to the Webpack assets manifest file, defaults to `dist/assets-manifest.json` in your theme.
 
+## Helpers
+
+Functions to interact with WordPress behaviour.
+
+### Plugin helper
+
+```php
+use Studiometa\WPToolkit\Helpers\PluginHelper;
+// Check if a specified plugin is enable.
+PluginHelper::is_plugin_enabled( 'my-plugin/my-plugin.php' );
+```
+
 ## Transient Cleaner
+
 ### Usage
+
 > **Important** Transients keys must be prefixed with transient cleaner prefix (`TransientCleaner::PREFIX`) to be tracked.
 
 ```php
@@ -144,7 +158,9 @@ $transient_cleaner->set_config(array());
 ```
 
 ## Contribute
+
 ### Run tests
+
 #### PHPUnit
 
 ```bash

--- a/src/Helpers/PluginHelper.php
+++ b/src/Helpers/PluginHelper.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Plugin helper functions.
+ *
+ * @package    studiometa/wp-toolkit
+ * @author     Studio Meta <agence@studiometa.fr>
+ * @copyright  2021 Studio Meta
+ * @license    https://opensource.org/licenses/MIT
+ * @since      1.0.0
+ * @version    1.0.0
+ */
+
+namespace Studiometa\WPToolkit\Helpers;
+
+/**
+ * Plugin helper class.
+ */
+class PluginHelper {
+	/**
+	 * Test if plugin is enabled.
+	 *
+	 * @param string $filepath Plugin filepath (relative to plugins folder).
+	 *
+	 * @return boolean Is plugin enabled?
+	 */
+	public static function is_plugin_enabled( string $filepath ):bool {
+		$cache_key      = __FUNCTION__ . md5( $filepath );
+		$cached_results = wp_cache_get( $cache_key, __CLASS__ );
+
+		if ( false !== $cached_results ) {
+			return (bool) $cached_results;
+		}
+
+		$is_enabled = is_plugin_active( $filepath );
+
+		wp_cache_set( $cache_key, (int) $is_enabled, __CLASS__ );
+
+		return $is_enabled;
+	}
+}

--- a/src/Helpers/PluginHelper.php
+++ b/src/Helpers/PluginHelper.php
@@ -21,6 +21,8 @@ class PluginHelper {
 	 *
 	 * @param string $filepath Plugin filepath (relative to plugins folder).
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @return boolean Is plugin enabled?
 	 */
 	public static function is_plugin_enabled( string $filepath ):bool {

--- a/tests/Helpers/PluginHelper.php
+++ b/tests/Helpers/PluginHelper.php
@@ -1,0 +1,19 @@
+<?php
+
+use Studiometa\WPToolkit\Helpers\PluginHelper;
+
+/**
+ * PluginHelperTest test case.
+ */
+class PluginHelperTest extends WP_UnitTestCase {
+	/**
+	 * Test `is_plugin_enabled` function.
+	 *
+	 * @return void
+	 */
+	public function test_is_plugin_enabled() {
+		$this->assertTrue(
+			is_bool( PluginHelper::is_plugin_enabled( 'my-plugin/my-plugin.php' ) )
+		);
+	}
+}


### PR DESCRIPTION
Add a function to check if a plugin is enabled.

I don't add `get_enabled_plugins` function because we rarely need to get a complete list of enabled plugins.

Fixes studiometa/create-wordpress-project#47