### PR TITLE
[Feature] Disable XML RPC endpoint by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **CleanupManager:** Disable XML-RPC by default ([#21](https://github.com/studiometa/wp-toolkit/pull/21))

--- a/src/Managers/CleanupManager.php
+++ b/src/Managers/CleanupManager.php
@@ -18,9 +18,24 @@ use Studiometa\WPToolkit\Managers\ManagerInterface;
  * Cleanup a WordPress project for security and performance.
  */
 class CleanupManager implements ManagerInterface {
-	// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	/**
-	 * @inheritdoc
+	 * Wether to enable XML RPC endpoint or not.
+	 *
+	 * @var bool
+	 */
+	protected $xml_rpc;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param bool $xml_rpc Enable or disable XML RPC.
+	 */
+	public function __construct( bool $xml_rpc = false ) {
+		$this->xml_rpc = $xml_rpc;
+	}
+
+	/**
+	 * {@inheritdoc}
 	 */
 	public function run() {
 		// Clean up <head>.
@@ -47,6 +62,8 @@ class CleanupManager implements ManagerInterface {
 
 		// Remove comments from the admin menu.
 		add_action( 'admin_menu', array( $this, 'remove_comments_from_admin_menu' ) );
+
+		add_filter( 'xmlrpc_enabled', array( $this, 'xmlrpc_enabled' ) );
 	}
 
 	/**
@@ -151,5 +168,12 @@ class CleanupManager implements ManagerInterface {
 	public function remove_comments_from_admin_menu():void {
 		// Remove comments admin menu item.
 		remove_menu_page( 'edit-comments.php' );
+	}
+
+	/**
+	 * Enable or disable XML RPC endpoint.
+	 */
+	public function xmlrpc_enabled():bool {
+		return $this->xml_rpc;
 	}
 }

--- a/tests/Managers/CleanupManagerTest.php
+++ b/tests/Managers/CleanupManagerTest.php
@@ -6,6 +6,14 @@ use Studiometa\WPToolkit\Managers\CleanupManager;
  * CleanupManagerTest test case.
  */
 class CleanupManagerTest extends WP_UnitTestCase {
+
+	/**
+	 * CleanupManager.
+	 *
+	 * @var CleanupManager
+	 */
+	public $cleanup_manager;
+
 	public function setUp():void {
 		parent::setUp();
 
@@ -27,5 +35,15 @@ class CleanupManagerTest extends WP_UnitTestCase {
 
 		$this->assertFalse( strpos( $updated_other_src, 'ver=' ) );
 		$this->assertNotFalse( strpos( $updated_theme_src, 'ver=' ) );
+	}
+
+	/**
+	 * Test disable XML RPC.
+	 *
+	 * @return void
+	 */
+	public function test_xml_rpc_disabled() {
+		$this->cleanup_manager->run();
+		$this->assertFalse( apply_filters( 'xmlrpc_enabled', true ) );
 	}
 }


### PR DESCRIPTION
XML-RPC is an old feature of WordPress, mainly targeted by bots. It can be disabled by default.

See https://kinsta.com/blog/xmlrpc-php/.