### PR TITLE
[Release] 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## v2.1.0 - 2024.03.12
+
 ### Added
 
 - Add a `Sentry` class to easily configure Sentry integration for both front-end and back-end ([#29](https://github.com/studiometa/wp-toolkit/pull/29))

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "studiometa/wp-toolkit",
-  "version": "2.0.0",
   "description": "WordPress utilities for Studio Meta.",
   "license": "MIT",
   "type": "library",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89f9329c94e91984010b7c885d1eda52",
+    "content-hash": "4ae9d81b385c475f971ba5f532cf6190",
     "packages": [
         {
             "name": "anahkiasen/html-object",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,5 +11,5 @@ parameters:
   paths:
       - ./src/
   ignoreErrors:
-    - message: '#^Parameter \#1 \$value of method\.#'
+    - message: '#^Action callback returns bool but should not return anything\.$#'
       path: ./src/TransientCleaner.php

--- a/src/TransientCleaner.php
+++ b/src/TransientCleaner.php
@@ -198,10 +198,11 @@ class TransientCleaner
      *
      * @param array|bool $value     New value.
      * @param array|bool $old_value Old value.
+     * @param string     $option    Option name.
      *
      * @return array|bool           New value
      */
-    public function merge_stored_transients_option_values($value, $old_value)
+    public function merge_stored_transients_option_values($value, $old_value, $option)
     {
         // Return `$value` if no previous value.
         if (false === $old_value) {


### PR DESCRIPTION
### Added

- Add a `Sentry` class to easily configure Sentry integration for both front-end and back-end ([#29](https://github.com/studiometa/wp-toolkit/pull/29))
