### PR TITLE
[Feature] Add `env_is_...` helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Add utility functions to test the current environment ([#31](https://github.com/studiometa/wp-toolkit/pull/31))
+
+
 ## v2.1.0 - 2024.03.12
 
 ### Added

--- a/src/Helpers/Env.php
+++ b/src/Helpers/Env.php
@@ -19,4 +19,67 @@ class Env
         // so we use `getenv` as a fallback to try and get the value.
         return $env[ $key ] ?? (string) getenv($key);
     }
+
+    /**
+     * Get the current APP_ENV configuration.
+     *
+     * @return string
+     */
+    private static function get_app_env(): string
+    {
+        return strtolower(self::get('APP_ENV'));
+    }
+
+    /**
+     * Test if the current environment is production.
+     * Both `production` and `prod` values are tested on the `APP_ENV` or
+     * `WP_ENV` environment variable or the `WP_ENV` constant.
+     *
+     * @return bool
+     */
+    public static function is_prod(): bool
+    {
+        $env = self::get_app_env();
+        return $env === 'production' || $env === 'prod';
+    }
+
+    /**
+     * Test if the current environment is preprod.
+     *
+     * @return bool
+     */
+    public static function is_preprod(): bool
+    {
+        return self::get_app_env() === 'preprod';
+    }
+
+    /**
+     * Test if the current environment is local.
+     *
+     * @return bool
+     */
+    public static function is_local(): bool
+    {
+        return self::get_app_env() === 'local';
+    }
+
+    /**
+     * Test if the current environment is staging.
+     *
+     * @return bool
+     */
+    public static function is_staging(): bool
+    {
+        return self::get_app_env() === 'staging';
+    }
+
+    /**
+     * Test if the current environment is development.
+     *
+     * @return bool
+     */
+    public static function is_development(): bool
+    {
+        return self::get_app_env() === 'development';
+    }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -23,6 +23,46 @@ function env(string $key): string
 }
 
 /**
+ * Test if the current environment is prod.
+ */
+function env_is_prod(): bool
+{
+    return Env::is_prod();
+}
+
+/**
+ * Test if the current environment is preprod.
+ */
+function env_is_preprod(): bool
+{
+    return Env::is_preprod();
+}
+
+/**
+ * Test if the current environment is local.
+ */
+function env_is_local(): bool
+{
+    return Env::is_local();
+}
+
+/**
+ * Test if the current environment is staging.
+ */
+function env_is_staging(): bool
+{
+    return Env::is_staging();
+}
+
+/**
+ * Test if the current environment is development.
+ */
+function env_is_development(): bool
+{
+    return Env::is_development();
+}
+
+/**
  * Get a Request instance from the symfony/http-foundation package.
  *
  * @see https://symfony.com/doc/current/components/http_foundation.html#request

--- a/tests/Helpers/EnvTest.php
+++ b/tests/Helpers/EnvTest.php
@@ -2,14 +2,14 @@
 
 namespace Studiometa\WPToolkitTest;
 
-use WP_UnitTestCase;
-use Studiometa\WPToolkit\Helpers\Env as EnvClass;
+use PHPUnit\Framework\TestCase;
+use Studiometa\WPToolkit\Helpers\Env;
 use function Studiometa\WPToolkit\env;
 
 /**
  * EnvTest test case.
  */
-class EnvTest extends WP_UnitTestCase
+class EnvTest extends TestCase
 {
 
     /**
@@ -20,6 +20,33 @@ class EnvTest extends WP_UnitTestCase
     public function test_type_of_request_function_helper()
     {
         $this->assertTrue(is_string(env('missing')));
-        $this->assertTrue(is_string(EnvClass::get('missing')));
+        $this->assertTrue(is_string(Env::get('missing')));
+    }
+
+    /**
+     * Test the `env_is_...` functions and methods.
+     *
+     * @return void
+     */
+    public function test_env_is_functions()
+    {
+        $mapping = [
+            'is_local'       => 'local',
+            'is_prod'        => 'production',
+            'is_prod'        => 'prod',
+            'is_preprod'     => 'preprod',
+            'is_development' => 'development',
+            'is_staging'     => 'staging',
+        ];
+
+        foreach ($mapping as $name => $value) {
+            $fn = sprintf('\Studiometa\WPToolkit\env_%s', $name);
+            $_ENV['APP_ENV'] = strtolower($value);
+            $this->assertTrue($fn());
+            $this->assertTrue(Env::$name());
+            $_ENV['APP_ENV'] = strtoupper($value);
+            $this->assertTrue($fn());
+            $this->assertTrue(Env::$name());
+        }
     }
 }


### PR DESCRIPTION
Add the following helper functions and methods for easier environment testing:

```php
use Studiometa\WPToolkit\Helpers\Env;
use function \Studiometa\WPToolkit\env_is_prod;
use function \Studiometa\WPToolkit\env_is_preprod;
use function \Studiometa\WPToolkit\env_is_local;
use function \Studiometa\WPToolkit\env_is_staging;
use function \Studiometa\WPToolkit\env_is_development;

env_is_prod(); // bool
env_is_preprod(); // bool
env_is_local(); // bool
env_is_staging(); // bool
env_is_development(); // bool

Env::is_prod(); // bool
Env::is_preprod(); // bool
Env::is_local(); // bool
Env::is_staging(); // bool
Env::is_development(); // bool
```