### PR TITLE
[Release] 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## v2.2.1 - 2024.03.28
+
+### Fixed
+
+- Allow passing custom options to `sentry_init()` ([a2641db](https://github.com/studiometa/wp-toolkit/commit/a2641db))
+
 ## v2.2.0 - 2024.03.28
 
 ### Added

--- a/src/Sentry/Sentry.php
+++ b/src/Sentry/Sentry.php
@@ -10,7 +10,7 @@ use function WeCodeMore\earlyAddAction as early_add_action;
 
 class Sentry
 {
-    public static function configureWithDefaults(string $root_dir): void
+    public static function configureWithDefaults(string $root_dir, array $options = []): void
     {
         $release = '';
 
@@ -37,12 +37,13 @@ class Sentry
                 traces_sample_rate: $traces_sample_rate,
                 profiles_sample_rate: $profiles_sample_rate,
             ),
+            $options
         );
     }
 
-    private static function configure(Config $config): void
+    private static function configure(Config $config, array $options = []): void
     {
-        init_sentry($config->toArray());
+        init_sentry($config->toArray() + $options);
 
         early_add_action('init', function () use ($config) {
             wp_enqueue_script('sentry-loader-script', $config->js_loader_script, []);


### PR DESCRIPTION
### Fixed

- Allow passing custom options to `sentry_init()` ([a2641db](https://github.com/studiometa/wp-toolkit/commit/a2641db))
