### PR TITLE
[Feature] Add support for custom taxonomies to FacetsManager 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Add support for custom taxonomies filtering ([#42](https://github.com/studiometa/wp-toolkit/issues/42), [#43](https://github.com/studiometa/wp-toolkit/pull/43), [ae541b5](https://github.com/studiometa/wp-toolkit/commit/ae541b5))
+
 ## v2.2.2 - 2024.04.19
 
 ### Fixed
@@ -49,9 +53,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add an `EmailManager` to configure `PHPMailer` via environment variables ([#22](https://github.com/studiometa/wp-toolkit/pull/22))
 - Add `enqueue_script($handle, $path)` and `enqueue_style($handle, $path)` method to the `AssetsManager` class ([#23](https://github.com/studiometa/wp-toolkit/pull/23))
 - Add a `Plugin::disable` method to the `Plugin` helper class ([#26](https://github.com/studiometa/wp-toolkit/pull/26))
-- Add a `request` helper function  ([#26](https://github.com/studiometa/wp-toolkit/pull/26))
+- Add a `request` helper function ([#26](https://github.com/studiometa/wp-toolkit/pull/26))
 - Add a `Request` helper class ([#26](https://github.com/studiometa/wp-toolkit/pull/26))
-- Add a `env` helper function  ([#26](https://github.com/studiometa/wp-toolkit/pull/26))
+- Add a `env` helper function ([#26](https://github.com/studiometa/wp-toolkit/pull/26))
 - Add a `Env` helper class ([#26](https://github.com/studiometa/wp-toolkit/pull/26))
 
 ### Changed

--- a/tests/Managers/FacetsManagerTest.php
+++ b/tests/Managers/FacetsManagerTest.php
@@ -51,4 +51,163 @@ class FacetsManagerTest extends WP_UnitTestCase
         $this->assertTrue($function instanceof TwigFunction);
         $this->assertTrue($function->getCallable()('cat') === 2);
     }
+
+    public function test_it_should_handle_taxonomy_queries_with_slugs()
+    {
+        // Register a test taxonomy
+        register_taxonomy('test_taxonomy', 'post', ['public' => true]);
+
+        request()->query->set('facets', ['test_taxonomy' => 'slug1,slug2']);
+        $manager = new FacetsManager();
+        $manager->run();
+
+        $this->go_to('/?facets[test_taxonomy]=slug1,slug2');
+        global $wp_query;
+
+        $tax_query = $wp_query->get('tax_query');
+        $this->assertIsArray($tax_query);
+        $this->assertCount(1, $tax_query);
+        $this->assertEquals('test_taxonomy', $tax_query[0]['taxonomy']);
+        $this->assertEquals('IN', $tax_query[0]['operator']);
+        $this->assertEquals('slug', $tax_query[0]['field']);
+        $this->assertEquals(['slug1', 'slug2'], $tax_query[0]['terms']);
+    }
+
+    public function test_it_should_handle_taxonomy_queries_with_ids()
+    {
+        register_taxonomy('test_taxonomy', 'post', ['public' => true]);
+
+        request()->query->set('facets', ['test_taxonomy' => '1,2,3']);
+        $manager = new FacetsManager();
+        $manager->run();
+
+        $this->go_to('/?facets[test_taxonomy]=1,2,3');
+        global $wp_query;
+
+        $tax_query = $wp_query->get('tax_query');
+        $this->assertEquals('term_id', $tax_query[0]['field']);
+        $this->assertEquals([1, 2, 3], $tax_query[0]['terms']);
+    }
+
+    public function test_it_should_handle_taxonomy_not_in_queries()
+    {
+        register_taxonomy('test_taxonomy', 'post', ['public' => true]);
+
+        request()->query->set('facets', ['test_taxonomy__not_in' => 'excluded-slug']);
+        $manager = new FacetsManager();
+        $manager->run();
+
+        $this->go_to('/?facets[test_taxonomy__not_in]=excluded-slug');
+        global $wp_query;
+
+        $tax_query = $wp_query->get('tax_query');
+        $this->assertEquals('test_taxonomy', $tax_query[0]['taxonomy']);
+        $this->assertEquals('NOT IN', $tax_query[0]['operator']);
+        $this->assertEquals(['excluded-slug'], $tax_query[0]['terms']);
+    }
+
+    public function test_it_should_handle_taxonomy_and_queries()
+    {
+        register_taxonomy('test_taxonomy', 'post', ['public' => true]);
+
+        request()->query->set('facets', ['test_taxonomy__and' => 'slug1,slug2']);
+        $manager = new FacetsManager();
+        $manager->run();
+
+        $this->go_to('/?facets[test_taxonomy__and]=slug1,slug2');
+        global $wp_query;
+
+        $tax_query = $wp_query->get('tax_query');
+        $this->assertEquals('AND', $tax_query[0]['operator']);
+    }
+
+    public function test_it_should_handle_taxonomy_exists_queries()
+    {
+        register_taxonomy('test_taxonomy', 'post', ['public' => true]);
+
+        request()->query->set('facets', ['test_taxonomy__exists' => '1']);
+        $manager = new FacetsManager();
+        $manager->run();
+
+        $this->go_to('/?facets[test_taxonomy__exists]=1');
+        global $wp_query;
+
+        $tax_query = $wp_query->get('tax_query');
+        $this->assertEquals('test_taxonomy', $tax_query[0]['taxonomy']);
+        $this->assertEquals('EXISTS', $tax_query[0]['operator']);
+        $this->assertArrayNotHasKey('terms', $tax_query[0]);
+        $this->assertArrayNotHasKey('field', $tax_query[0]);
+    }
+
+    public function test_it_should_combine_taxonomy_and_regular_queries()
+    {
+        register_taxonomy('test_taxonomy', 'post', ['public' => true]);
+
+        request()->query->set('facets', [
+            'test_taxonomy' => 'test-slug',
+            'meta_key' => 'custom_field',
+            'posts_per_page' => 5
+        ]);
+        $manager = new FacetsManager();
+        $manager->run();
+
+        $this->go_to('/?facets[test_taxonomy]=test-slug&facets[meta_key]=custom_field&facets[posts_per_page]=5');
+        global $wp_query;
+
+        // Check taxonomy query
+        $tax_query = $wp_query->get('tax_query');
+        $this->assertIsArray($tax_query);
+        $this->assertEquals('test_taxonomy', $tax_query[0]['taxonomy']);
+
+        // Check regular query vars
+        $this->assertEquals('custom_field', $wp_query->query_vars['meta_key']);
+        $this->assertEquals(5, $wp_query->query_vars['posts_per_page']);
+    }
+
+    public function test_it_should_handle_existing_tax_query()
+    {
+        register_taxonomy('test_taxonomy', 'post', ['public' => true]);
+
+        request()->query->set('facets', ['test_taxonomy' => 'new-slug']);
+        $manager = new FacetsManager();
+        $manager->run();
+
+        // Set up existing tax_query
+        $existing_tax_query = [
+            [
+                'taxonomy' => 'category',
+                'field' => 'slug',
+                'terms' => ['existing-category'],
+                'operator' => 'IN'
+            ]
+        ];
+
+        $this->go_to('/?facets[test_taxonomy]=new-slug');
+        global $wp_query;
+        $wp_query->set('tax_query', $existing_tax_query);
+
+        // Trigger the facets query modification
+        $manager->add_facets_to_query($wp_query);
+
+        $tax_query = $wp_query->get('tax_query');
+        $this->assertCount(2, $tax_query);
+        $this->assertEquals('test_taxonomy', $tax_query[0]['taxonomy']);
+        $this->assertEquals('category', $tax_query[1][0]['taxonomy']);
+    }
+
+    public function test_it_should_handle_array_values_in_facets()
+    {
+        register_taxonomy('test_taxonomy', 'post', ['public' => true]);
+
+        request()->query->set('facets', ['test_taxonomy' => ['slug1', 'slug2']]);
+        $manager = new FacetsManager();
+        $manager->run();
+
+        $this->go_to('/?facets[test_taxonomy][]=slug1&facets[test_taxonomy][]=slug2');
+        global $wp_query;
+
+        $tax_query = $wp_query->get('tax_query');
+        $this->assertEquals(['slug1', 'slug2'], $tax_query[0]['terms']);
+        $this->assertEquals('slug', $tax_query[0]['field']);
+    }
 }


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#42

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for custom taxonomy to the URL parameters for the FacetsManager.

With a custom taxonomy named `text_taxonomy`, the following parameters can be used:

```
?facets[test_taxonomy]=slug1,slug2
?facets[test_taxonomy]=1,2,3
?facets[test_taxonomy__not_in]=excluded-slug
?facets[test_taxonomy__and]=slug1,slug2
?facets[test_taxonomy__exists]=1
```

As of now the `relation` operator for tax queries is not configurable and will always be `AND`. Usage will tell us if customization is needed.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog.
