### PR TITLE
[Bugfix] Fix the FacetsManager modifying non-main queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix facets applying on non-main queries ([#49](https://github.com/studiometa/wp-toolkit/issues/49), [#50](https://github.com/studiometa/wp-toolkit/pull/50), [9c098c7](https://github.com/studiometa/wp-toolkit/commit/9c098c7))
+
 ## v2.3.0 - 2024.08.14
 
 ### Added

--- a/src/Managers/FacetsManager.php
+++ b/src/Managers/FacetsManager.php
@@ -58,7 +58,7 @@ class FacetsManager implements ManagerInterface
      */
     public function add_facets_to_query(WP_Query &$query): void
     {
-        if (!is_array($this->facets)) {
+        if (!is_array($this->facets) || !$query->is_main_query()) {
             return;
         }
 

--- a/tests/Managers/FacetsManagerTest.php
+++ b/tests/Managers/FacetsManagerTest.php
@@ -210,4 +210,21 @@ class FacetsManagerTest extends WP_UnitTestCase
         $this->assertEquals(['slug1', 'slug2'], $tax_query[0]['terms']);
         $this->assertEquals('slug', $tax_query[0]['field']);
     }
+
+    public function test_it_should_not_add_facets_to_non_main_query()
+    {
+        request()->query->set('facets', ['cat' => 1]);
+        $manager = new FacetsManager();
+        $manager->run();
+
+        // Create a non-main query
+        $secondary_query = new WP_Query();
+        $secondary_query->init();
+        
+        // Manually call the method to simulate what happens on pre_get_posts
+        $manager->add_facets_to_query($secondary_query);
+
+        // The facets should not be applied to the secondary query
+        $this->assertFalse(isset($secondary_query->query_vars['cat']));
+    }
 }


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#49 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes a bug where the FacetsManager was adding query vars to all `WP_Query` instances, not just the main one. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
